### PR TITLE
Use variables directly in templates

### DIFF
--- a/src/templates/404.phtml
+++ b/src/templates/404.phtml
@@ -1,4 +1,12 @@
-<h1>Ooooops!</h1>
+<html>
+<head>
+    <title>Example Application</title>
+    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+</head>
+<body>
+    <h1>Ooooops!</h1>
 
-<p><b>Message: </b> <?=$exception->getMessage();?></p>
-<p>On line <?=$exception->getLine();?> in <?=$exception->getFile();?></p>
+    <p><b>Message: </b> <?=$exception->getMessage();?></p>
+    <p>On line <?=$exception->getLine();?> in <?=$exception->getFile();?></p>
+</body>
+</html>

--- a/src/templates/ticketadd.phtml
+++ b/src/templates/ticketadd.phtml
@@ -17,13 +17,10 @@
     <select name="component">
         <option value=""></option>
 <?php
-if($data['components'] && is_array($data['components'])): 
-    foreach($data['components'] as $component): ?>
-
-        <option value=<?=$component->getId()?>><?=$component->getName()?></option>
+foreach($components as $component): ?>
+    <option value="<?=$component->getId()?>"><?=$component->getName()?></option>
 <?php
-    endforeach;
-endif;
+endforeach;
 ?>
     </select><br />
 

--- a/src/templates/ticketdetail.phtml
+++ b/src/templates/ticketdetail.phtml
@@ -4,7 +4,6 @@
     <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
 </head>
 <body>
-<?php $ticket = $data['ticket'] ?>
 <h1><?=$ticket->getTitle()?></h1>
 
 <p><strong><?=$ticket->getDescription()?></strong></p>

--- a/src/templates/tickets.phtml
+++ b/src/templates/tickets.phtml
@@ -9,7 +9,7 @@
 <p><a href="/ticket/new">Add new ticket</a></p>
 
 <?php
-if($data['tickets'] && is_array($data['tickets'])):
+if(count($tickets) > 0):
 ?>
 <table class="pure-table">
     <tr>
@@ -20,8 +20,8 @@ if($data['tickets'] && is_array($data['tickets'])):
     </tr>
 
 <?php
-    $odd = 1;
-    foreach($data['tickets'] as $ticket): ?>
+    $odd = true;
+    foreach($tickets as $ticket): ?>
 
         <tr <?=$odd ? "class=\"pure-table-odd\"" : ""; ?>>
         <td><?=$ticket->getTitle() ?></td>
@@ -33,12 +33,11 @@ if($data['tickets'] && is_array($data['tickets'])):
     </tr>
 
 <?php 
-    $odd = $odd ? 0 : 1;
+    $odd = $odd ? false : true;
     endforeach; ?>
 </table>
 <?php else: ?>
 <p>No current tickets</p>
-
 <?php endif; ?>
 
 </body>


### PR DESCRIPTION
I noticed in the variables in templates are sometimes fetched using `$data`, e.g. `$data['components']` instead of just `$components`. 
