### PR TITLE
remove spl_autoload_register usage

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -4,5 +4,10 @@
         "slim/php-view": "^2.0",
         "monolog/monolog": "^1.17",
         "robmorgan/phinx": "^0.5.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "": "classes/"
+        }
     }
 }

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,11 +1,9 @@
 <?php
+
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
 
-require '../vendor/autoload.php';
-spl_autoload_register(function ($classname) {
-    require ("../classes/" . $classname . ".php");
-});
+require __DIR__ . '/../vendor/autoload.php';
 
 $config['displayErrorDetails'] = true;
 $config['db']['host']   = "localhost";


### PR DESCRIPTION
Replaces spl_autoload_register usage with PSR-4 autoloading, as discussed in channel today.